### PR TITLE
Support multiple targets

### DIFF
--- a/Sources/SSGH/SSGH.swift
+++ b/Sources/SSGH/SSGH.swift
@@ -5,7 +5,7 @@ import SSGHCore
 @main
 struct SSGH: ParsableCommand {
     @Argument(help: "GitHub user name to give stars.")
-    var target: String
+    var targets: [String]
 
     @Option(name: [.customLong("github-token"), .customShort("t")],
             help: "GitHub Token to give stars. If not set, use `SSGH_TOKEN` in environment.")
@@ -28,7 +28,7 @@ extension SSGH {
             try SSGHCore(
                 gitHubToken: gitHubToken,
                 dryRunMode: dryRunMode
-            ).execute(mode: . specifiedTargets(target))
+            ).execute(mode: . specifiedTargets(targets))
         } catch {
             dumpError(error)
             Self.exit(withError: error)

--- a/Sources/SSGH/SSGH.swift
+++ b/Sources/SSGH/SSGH.swift
@@ -28,7 +28,7 @@ extension SSGH {
             try SSGHCore(
                 gitHubToken: gitHubToken,
                 dryRunMode: dryRunMode
-            ).execute(mode: .target(target))
+            ).execute(mode: . specifiedTargets(target))
         } catch {
             dumpError(error)
             Self.exit(withError: error)

--- a/Sources/SSGH/SSGH.swift
+++ b/Sources/SSGH/SSGH.swift
@@ -26,10 +26,9 @@ extension SSGH {
         let gitHubToken = try gitHubToken ?? (try Environment.getValue(forKey: .gitHubToken))
         do {
             try SSGHCore(
-                target: target,
                 gitHubToken: gitHubToken,
                 dryRunMode: dryRunMode
-            ).execute()
+            ).execute(mode: .target(target))
         } catch {
             dumpError(error)
             Self.exit(withError: error)

--- a/Sources/SSGHCore/Common/Console.swift
+++ b/Sources/SSGHCore/Common/Console.swift
@@ -31,6 +31,10 @@ public func dumpWarn(_ message: @autoclosure () -> String, file: StaticString = 
     dump(logType: .warn, message(), file: file, line: line)
 }
 
+public func dumpWarn(_ error: @autoclosure () -> Error, file: StaticString = #file, line: UInt = #line) {
+    dumpWarn("\(error())", file: file, line: line)
+}
+
 private func dump(
     logType: LogType,
     _ message: @autoclosure () -> String,

--- a/Sources/SSGHCore/Common/Console.swift
+++ b/Sources/SSGHCore/Common/Console.swift
@@ -24,7 +24,7 @@ public func dumpError(_ message: @autoclosure () -> String, file: StaticString =
 }
 
 public func dumpError(_ error: @autoclosure () -> Error, file: StaticString = #file, line: UInt = #line) {
-    dumpError("\(error())", file: file, line: line)
+    dumpError(error().localizedDescription, file: file, line: line)
 }
 
 public func dumpWarn(_ message: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) {
@@ -32,7 +32,7 @@ public func dumpWarn(_ message: @autoclosure () -> String, file: StaticString = 
 }
 
 public func dumpWarn(_ error: @autoclosure () -> Error, file: StaticString = #file, line: UInt = #line) {
-    dumpWarn("\(error())", file: file, line: line)
+    dumpWarn(error().localizedDescription, file: file, line: line)
 }
 
 private func dump(

--- a/Sources/SSGHCore/Error.swift
+++ b/Sources/SSGHCore/Error.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension SSGHCore {
+    enum Error {
+        case targetUnspecified
+    }
+}
+
+extension SSGHCore.Error: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .targetUnspecified:
+            return "Specify at least one target."
+        @unknown default:
+            return nil
+        }
+    }
+}

--- a/Sources/SSGHCore/SSGHCore.swift
+++ b/Sources/SSGHCore/SSGHCore.swift
@@ -28,7 +28,8 @@ public extension SSGHCore {
                     dumpWarn(error)
                     return nil
                 }
-            }.forEach(star(to:))
+            }
+            .forEach(star(to:))
         }
     }
 }

--- a/Sources/SSGHCore/SSGHCore.swift
+++ b/Sources/SSGHCore/SSGHCore.swift
@@ -20,9 +20,10 @@ public extension SSGHCore {
         case let .specifiedTargets(target):
             dumpInfo("Fetching users...")
             try target.compactMap {
-                do {
-                    return try gitHubClient.getUser(by: $0).get()
-                } catch {
+                switch gitHubClient.getUser(by: $0) {
+                case let .success(user):
+                    return user
+                case let .failure(error):
                     dumpWarn(error)
                     return nil
                 }

--- a/Sources/SSGHCore/SSGHCore.swift
+++ b/Sources/SSGHCore/SSGHCore.swift
@@ -19,8 +19,14 @@ public extension SSGHCore {
         switch mode {
         case let .specifiedTargets(target):
             dumpInfo("Fetching users...")
-            try target.map { try gitHubClient.getUser(by: $0).get() }
-                .forEach(star(to:))
+            try target.compactMap {
+                do {
+                    return try gitHubClient.getUser(by: $0).get()
+                } catch {
+                    dumpWarn(error)
+                    return nil
+                }
+            }.forEach(star(to:))
         }
     }
 }

--- a/Sources/SSGHCore/SSGHCore.swift
+++ b/Sources/SSGHCore/SSGHCore.swift
@@ -17,9 +17,10 @@ public extension SSGHCore {
     func execute(mode: Mode) throws {
         defer { confirmUpdate() }
         switch mode {
-        case let .specifiedTargets(target):
+        case let .specifiedTargets(targets):
+            if targets.isEmpty { throw Error.targetUnspecified }
             dumpInfo("Fetching users...")
-            try target.compactMap {
+            try targets.compactMap {
                 switch gitHubClient.getUser(by: $0) {
                 case let .success(user):
                     return user

--- a/Sources/SSGHCore/SSGHCore.swift
+++ b/Sources/SSGHCore/SSGHCore.swift
@@ -17,7 +17,7 @@ public extension SSGHCore {
     func execute(mode: Mode) throws {
         defer { confirmUpdate() }
         switch mode {
-        case let .target(target):
+        case let .specifiedTargets(target):
             dumpInfo("Fetching users...")
             try target.map { try gitHubClient.getUser(by: $0).get() }
                 .forEach(star(to:))
@@ -82,7 +82,7 @@ private extension SSGHCore {
 
 public extension SSGHCore {
     enum Mode {
-        case target([String])
+        case specifiedTargets([String])
         // TODO: Future support
         // case following
     }

--- a/Tests/SSGHCoreTests/SSGHCoreTests.swift
+++ b/Tests/SSGHCoreTests/SSGHCoreTests.swift
@@ -12,21 +12,19 @@ final class SSGHCoreTests: XCTestCase {
     }
 
     func testExecute() throws {
-        let core = SSGHCore(target: "417-72KI",
-                            gitHubClient: client,
+        let core = SSGHCore(gitHubClient: client,
                             dryRunMode: false)
         XCTAssertEqual(client.starredRepos, [])
-        try core.execute()
+        try core.execute(mode: .specifiedTargets(["417-72KI", "octocat"]))
 
-        XCTAssertEqual(client.starredRepos, Set(client.repos["417-72KI"] ?? []))
+        XCTAssertEqual(client.starredRepos, Set(client.repos.values.flatMap { $0 }))
     }
 
     func testExecuteWithDryRunMode() throws {
-        let core = SSGHCore(target: "417-72KI",
-                            gitHubClient: client,
+        let core = SSGHCore(gitHubClient: client,
                             dryRunMode: true)
         XCTAssertEqual(client.starredRepos, [])
-        try core.execute()
+        try core.execute(mode: .specifiedTargets(["417-72KI", "octocat"]))
 
         XCTAssertEqual(client.starredRepos, [])
     }


### PR DESCRIPTION
- Prepare for multiple targets
- Rename
- Apply multiple
- Just dump warning and don't stop executing
- `do-catch` -> `switch` for `Swift.Result`
- throw error on empty targets
- Fix dump error
- fix `SSGHCoreTests`
