### PR TITLE
Replace deprecated `::set-output`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,8 @@ jobs:
         run: |
           xcode_version=$(cat .github/versions.json | jq -rc '.xcode_version')
           swift_version=$(cat .github/versions.json | jq -rc '.swift_version | max')
-          echo "::set-output name=xcode-version::$xcode_version"
-          echo "::set-output name=swift-version::$swift_version"
+          echo "xcode-version=$xcode_version" >> $GITHUB_OUTPUT
+          echo "swift-version=$swift_version" >> $GITHUB_OUTPUT
     outputs:
       xcode-version: ${{ steps.set-matrix.outputs.xcode-version }}
       swift-version: ${{ steps.set-matrix.outputs.swift-version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,7 +20,7 @@ jobs:
         id: resolve
         run: |
           swift package resolve
-          echo "::set-output name=count::$(git diff --name-only | grep -E '^Package.resolved$' | wc -l)"
+          echo "count=$(git diff --name-only | grep -E '^Package.resolved$' | wc -l)" >> $GITHUB_OUTPUT
       - name: Commit Package.resolved
         if: steps.resolve.outputs.count > 0
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - id: set-matrix
         run: |
           matrix=$(cat .github/versions.json | jq -rc .)
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   macOS:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/